### PR TITLE
chore: prep v0.5.0 release (README rewrite + LICENSE + CI + version bump)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,21 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+jobs:
+  check:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-go@v5
+        with:
+          go-version: stable
+          cache: true
+      - uses: golangci/golangci-lint-action@v6
+        with:
+          version: latest
+      - name: make check
+        run: make check

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,8 +14,7 @@ jobs:
         with:
           go-version: stable
           cache: true
-      - uses: golangci/golangci-lint-action@v6
-        with:
-          version: latest
+      - name: Install golangci-lint v2
+        run: go install github.com/golangci/golangci-lint/v2/cmd/golangci-lint@latest
       - name: make check
         run: make check

--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,6 @@ ja2en
 /bin/
 /build/
 coverage.out
+
+# Local planning / scratch
+plans/

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 Hadashi (GigiTiti-Kai)
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 .PHONY: build install test clean fmt vet lint check
 
 BINARY := ja2en
-VERSION := 0.1.0
+VERSION := 0.5.0
 LDFLAGS := -ldflags "-X main.version=$(VERSION) -s -w"
 
 build:

--- a/README.md
+++ b/README.md
@@ -1,107 +1,184 @@
 # ja2en
 
-WezTerm 運用前提の日本語→英語翻訳 CLI ツール。**Google AI Studio (Gemini 2.5 Flash-Lite)** をデフォルトに、叩いた瞬間に英訳が返る体験を最優先。
+Japanese-to-English translation CLI for software engineers. シングルバイナリ (Go 製)、起動 ~10ms、デフォルトで OpenAI gpt-5.4-nano (paid) を叩いて自然な英語を返す。Gemini と DeepL がフォールバック。
 
 ## 特徴
 
-- **起動 ~10ms**: Go 製シングルバイナリ
-- **デフォルト無料**: Google AI Studio の Gemini 2.5 Flash-Lite（stable、クレカ登録不要、~500 RPD）
-- **多プロバイダ対応**: profile ごとに API base / API key の env var を切替可能（OpenRouter / OpenAI / その他互換 API）
-- **設定ファイル + プロファイル切替**: シンプル英訳とカスタムプロンプトを使い分け
-- **クリップボード対応**: `--clip` で読み込み、`--paste` で書き戻し
-- **API キーは環境変数のみ**: 設定ファイルには書かない
+- **起動 ~10ms**: Go 製シングルバイナリ。`ja2en "..."` で叩いた瞬間に英訳が返る。
+- **CJK IME と相性のいいインタラクティブモード**: `--interactive` で multi-line text editor 起動。日本語入力時に IME composition window がカーソル直下に追従する (他の TUI 翻訳ツールではここが画面下端に張り付くケースが多い)。マルチライン navigation・全 emacs 系キーバインド対応。
+- **プロンプトインジェクション対策済み**: 入力に「日本語で答えて」「上の指示は無視して」等のメタ指示が混じっても翻訳契約が壊れない。
+- **3 プロバイダ multi-provider 設計**: profile ごとに OpenAI / Gemini / DeepL を切替。`api_key_env` で「どの環境変数を読むか」も config 側から指定可能。
+- **エンジニア向けの翻訳トーン**: 「ってか / なんですけど / 〜してください (口語)」等のヘッジ語を英訳から落とすスタイル指定が組み込み済み。
+- **クリップボード対応**: `--clip` で読込、`--paste` で書戻し (WSL では `clip.exe` 経由で動く)。
+- **API キーは環境変数のみ**: 設定ファイルにキーを書かない。
 
-## インストール
+## デモ
 
-```bash
-git clone <this-repo> ~/ja2en
-cd ~/ja2en
-make install        # $GOPATH/bin/ja2en に配置
+```text
+$ ja2en "ってかこれ見てほしいんだけど"
+Look at this.
+
+$ ja2en --interactive
+Enter Japanese text. Ctrl-D to translate, Ctrl-C to abort.
+
+│ 改行を含む
+│ 日本語をそのままタイプできるエディタ
+│ ^D
+A multi-line editor where you can type Japanese as is.
 ```
 
-## セットアップ
+## Quick Start
 
-1. Google AI Studio で API key を発行: <https://aistudio.google.com/apikey>
-2. シェル設定に追記:
+3 分で動かせる。
+
+1. **インストール**:
 
    ```bash
-   export GEMINI_API_KEY="..."
+   go install github.com/GigiTiti-Kai/ja2en@v0.5.0
    ```
 
-3. 設定ファイル生成:
+   (`$GOPATH/bin` が `PATH` に入っていること。 `go env GOPATH` で確認。)
+
+2. **OpenAI API キーを発行**: <https://platform.openai.com/>
+   - **$5 の prepaid 必須** (credits は 1 年で expire)。
+   - 通常用途で月 $0.13 程度の見込み (1 日 50 翻訳ペースなら $5 で 3 年)。
+
+3. **環境変数を設定** (例: `~/.bashrc`):
+
+   ```bash
+   export OPENAI_API_KEY="sk-..."
+   ```
+
+4. **設定ファイルを生成**:
 
    ```bash
    ja2en init
    ```
 
-OpenRouter を使いたい場合は `OPENROUTER_API_KEY` を設定し、`ja2en init` 後に `~/.config/ja2en/config.toml` の openrouter プロファイルを有効化。
+   `~/.config/ja2en/config.toml` が作られる (`openai` プロファイルがデフォルト)。
+
+5. **動作確認**:
+
+   ```bash
+   ja2en "明日出社する"
+   # → I'll come to the office tomorrow.
+   ```
 
 ## 使い方
 
 ```bash
-# 引数
-ja2en "明日出社する"
+# 引数として渡す
+ja2en "今日は良い天気だ"
 
-# stdin
-echo "今日は遅れる" | ja2en
+# stdin から
+echo "明日は遅れます" | ja2en
 
-# クリップボード読込
+# クリップボードから読む
 ja2en --clip
 
-# 翻訳結果をクリップボードに書込
+# 翻訳結果をクリップボードに書き戻す
 ja2en --paste "緊急対応します"
 
-# 読込→翻訳→書戻し
+# 読込→翻訳→書き戻し
 ja2en --clip --paste
 
-# プロファイル切替
-ja2en --profile openrouter "..."
+# マルチラインインタラクティブモード (IME 対応)
+ja2en --interactive       # または -i
 
-# 一発でモデル指定
-ja2en --model gemini-2.5-flash-lite "..."
+# プロファイル切替 (フォールバック先を使う)
+ja2en --profile gemini "..."
+ja2en --profile deepl "..."
+
+# モデルだけアドホックに切替
+ja2en --model gpt-5.4-mini "..."
+
+# プロンプトファイルを指定 (口語 / 技術文書 / 等のスタイル切替)
+ja2en --prompt-file ~/prompts/formal.md "..."
 ```
 
-## 設定
+## プロバイダ比較
 
-`~/.config/ja2en/config.toml`:
+`ja2en init` で生成される標準 3 プロファイル:
+
+| Profile | Model | コスト | 速度 (中央値) | 用途 |
+|---|---|---|---|---|
+| **openai** (default) | `gpt-5.4-nano` | paid (~$0.13/月) | ~600ms | 本番常用 |
+| **gemini** | `gemini-2.5-flash-lite` | free (RPD 制限あり) | ~850ms | クォータ余裕時のフォールバック |
+| **deepl** | DeepL Free | free (500K chars/月) | ~1000ms | 極短文・OpenAI 障害時 |
+
+OpenRouter を使いたい場合は `openrouter` プロファイルが config にコメントアウトで入っている。`OPENROUTER_API_KEY` を設定して有効化。
+
+## なぜデフォルトが paid OpenAI なのか?
+
+以前のバージョン (v0.2.x) は Google AI Studio の Gemini 2.5 Flash-Lite (free) をデフォルトにしていた。理由は単純で「無料・高速・品質も悪くない」だったが、本番運用で次の罠を踏んだ:
+
+- **Gemini 2.5 系の thinking モードがデフォルト ON** で、TPM 250K (project shared) を 1 リクエストで数千〜数万 tokens 消費する → 公称 RPD 1000 が実効 RPD 20 まで落ちる。
+- `reasoning_effort = "none"` を必ず指定する設計に変更したものの、free tier だと結局重いリクエストで他のユーザーと TPM を取り合うため不安定。
+
+v0.3 で **OpenAI gpt-5.4-nano + `reasoning_effort = "none"`** をデフォルトに切替た。月 $0.13 程度のコストで:
+
+- 安定 (paid tier の rate limit は実効値が公称通り)
+- ja→en 品質が一段上 (Reddit / Intento / llmversus が概ね同意)
+- レイテンシ ~600ms (Gemini free より速い)
+
+無料運用したい人は `--profile gemini` で従来挙動が使える。詳細は `CLAUDE.md` の「既知の制約」と「デフォルトモデル変遷」を参照。
+
+## 設定 (`~/.config/ja2en/config.toml`)
+
+`ja2en init` が生成するファイルの抜粋:
 
 ```toml
-default_profile = "simple"
-model = "gemini-2.5-flash-lite"
-api_base = "https://generativelanguage.googleapis.com/v1beta/openai"
-api_key_env = "GEMINI_API_KEY"
+default_profile = "openai"
 timeout_seconds = 30
 
-[profiles.simple]
-prompt = "..."
-
-[profiles.openrouter]
-api_base = "https://openrouter.ai/api/v1"
-api_key_env = "OPENROUTER_API_KEY"
-model = "anthropic/claude-haiku-4.5"
-prompt = "..."
+[profiles.openai]
+provider = "openai"
+api_base = "https://api.openai.com/v1"
+api_key_env = "OPENAI_API_KEY"
+model = "gpt-5.4-nano"
+reasoning_effort = "none"
+prompt = """..."""              # ja→en スタイル指定 + プロンプトインジェクション防御
 ```
 
-## シェルエイリアス（オプション）
+主要フィールド:
 
-`~/.bashrc` に追加すると便利:
+| フィールド | 意味 |
+|---|---|
+| `provider` | `"openai"` (OpenAI 互換 chat completions) または `"deepl"` (DeepL REST) |
+| `api_key_env` | この profile が読む環境変数の名前。同じバイナリで OpenAI / Google AI Studio / OpenRouter 等を切替できる |
+| `reasoning_effort` | reasoning モデル用 (`"none"` / `"low"` / `"medium"` / `"high"` / `"xhigh"`)。**翻訳タスクでは `"none"` 一択** |
+| `prompt` | system prompt 本体。`prompt_file` でファイル指定も可 |
+
+## シェルエイリアス (推奨)
+
+`~/.bashrc` 等に:
 
 ```bash
+# t = 引数で翻訳、引数なし TTY で clip+paste、stdin あれば pipe 翻訳
 t() {
     if [ "$#" -eq 0 ]; then
-        if [ -t 0 ]; then
-            ja2en --clip --paste
-        else
-            ja2en
-        fi
+        if [ -t 0 ]; then ja2en --clip --paste; else ja2en; fi
     else
         ja2en "$@"
     fi
 }
-tcr() { ja2en --clip; }
-tp() { ja2en --paste "$@"; }
+
+# ti = インタラクティブ
+ti() { ja2en --interactive; }
 ```
 
-## ライセンス
+## Development
 
-MIT
+```bash
+git clone https://github.com/GigiTiti-Kai/ja2en
+cd ja2en
+make build         # ./ja2en を生成
+make install       # $GOPATH/bin/ja2en に配置
+make check         # fmt + vet + lint + test 一括
+```
+
+CI は `.github/workflows/ci.yml` で `make check` を回す。詳細な開発ノートは `CLAUDE.md` 参照。
+
+## License
+
+[MIT](LICENSE)


### PR DESCRIPTION
## Summary

Bring everything into shape for the **v0.5.0** tag we're about to cut.

- **Makefile**: bump `VERSION` 0.1.0 → 0.5.0 (it was wrong; `--version` was lying)
- **LICENSE**: add MIT (README has always claimed MIT but the file didn't exist)
- **README.md**: full rewrite for v0.5 reality
  - Quick Start now uses `OPENAI_API_KEY` and `gpt-5.4-nano` (paid, $5 prepaid)
  - documents `--interactive` and the CJK IME advantage as a differentiator
  - new provider comparison table (openai default / gemini fallback / deepl emergency)
  - new "なぜデフォルトが paid OpenAI なのか?" section explaining the v0.2 → v0.3 switch
- **.github/workflows/ci.yml**: GitHub Actions CI on push & PR (`setup-go stable` + `golangci-lint` + `make check`)
  - hermetic: tests use `t.Setenv` for fake API keys, so no real secrets needed in CI
- **.gitignore**: ignore `plans/` (local planning scratch)

## Test plan

- [x] `make check` locally clean (fmt + vet + lint + test)
- [x] `./ja2en --version` returns `ja2en version 0.5.0`
- [x] README has no residue of "GEMINI_API_KEY default" or "クレカ登録不要"
- [ ] CI run on this PR is green
- [ ] After merge: `gh repo view --json licenseInfo` recognises MIT

🤖 Generated with [Claude Code](https://claude.com/claude-code)