### PR TITLE
fix: report module version when installed via go install

### DIFF
--- a/main.go
+++ b/main.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"fmt"
 	"os"
+	"runtime/debug"
 	"time"
 
 	"github.com/spf13/cobra"
@@ -27,7 +28,23 @@ type translatorClient interface {
 }
 
 // version is overridden at build time via -ldflags "-X main.version=..."
+// (set by the Makefile). When installed via `go install <module>@<tag>` the
+// Makefile is bypassed, so init() falls back to runtime/debug.BuildInfo
+// which carries the module tag (e.g. "v0.5.0").
 var version = "dev"
+
+func init() {
+	if version != "dev" {
+		return
+	}
+	info, ok := debug.ReadBuildInfo()
+	if !ok {
+		return
+	}
+	if v := info.Main.Version; v != "" && v != "(devel)" {
+		version = v
+	}
+}
 
 func main() {
 	rootCmd := newRootCmd()


### PR DESCRIPTION
## Summary

`go install github.com/GigiTiti-Kai/ja2en@v0.5.0` shows `ja2en version dev` because that path bypasses the Makefile (`-ldflags "-X main.version=..."` never runs).

Add `runtime/debug.ReadBuildInfo()` fallback in `init()`:
- If the ldflag was set (Makefile path), `version != "dev"` and we keep that value.
- If not, pull the module tag from `BuildInfo.Main.Version` (e.g. `"v0.5.0"`).
- Local `go build` from a clean checkout returns `"(devel)"` from BuildInfo, which we ignore — keeps "dev" so it's clear you're not on a tag.

## Test plan

- [x] `make build && ./ja2en --version` → `ja2en version 0.5.0` (ldflag wins)
- [x] `make check` clean
- [ ] CI green
- [ ] After merge + v0.5.1 tag: `go install github.com/GigiTiti-Kai/ja2en@v0.5.1` then `--version` returns `v0.5.1`

🤖 Generated with [Claude Code](https://claude.com/claude-code)