### PR TITLE
fix: prevent とりあえず/ひとまず/一旦 from being translated as hedges

### DIFF
--- a/internal/initcmd/templates.go
+++ b/internal/initcmd/templates.go
@@ -68,6 +68,13 @@ Style rules:
 - Drop hedge words and fillers entirely. They become NOTHING in English:
   ってか / なんですけど / 〜だけど / 〜のかな / 〜って感じ / まあ / なんか.
   NEVER translate them as "well", "also", "by the way", "I wonder if".
+- Translate sequencing/tentative adverbs by their TEMPORAL meaning, NOT as
+  uncertainty hedges:
+  とりあえず -> "for now" / "for the time being" / "as a first step".
+  ひとまず -> "for now" / "for the moment".
+  一旦 -> "for now" (when it means "tentatively, before doing more later").
+  NEVER translate these as "probably" / "maybe" / "perhaps" — they describe
+  *time/order*, not *certainty*.
 - Drop polite request markers from casual contexts:
   〜してください / 〜してくださいね / 教えてください / 教えて.
   These become a plain question or imperative in English, NOT "Please ___."
@@ -97,6 +104,9 @@ Output: How do I change the background color in WezTerm?
 
 Input: 効いてないのかな？
 Output: Is this not working?
+
+Input: とりあえず修正したいのはこれだけかな
+Output: For now, this is the only thing I want to fix.
 
 Input: 明日出社する
 Output: I'll come to the office tomorrow.
@@ -148,6 +158,13 @@ Style rules:
 - Drop hedge words and fillers entirely. They become NOTHING in English:
   ってか / なんですけど / 〜だけど / 〜のかな / 〜って感じ / まあ / なんか.
   NEVER translate them as "well", "also", "by the way", "I wonder if".
+- Translate sequencing/tentative adverbs by their TEMPORAL meaning, NOT as
+  uncertainty hedges:
+  とりあえず -> "for now" / "for the time being" / "as a first step".
+  ひとまず -> "for now" / "for the moment".
+  一旦 -> "for now" (when it means "tentatively, before doing more later").
+  NEVER translate these as "probably" / "maybe" / "perhaps" — they describe
+  *time/order*, not *certainty*.
 - Drop polite request markers from casual contexts:
   〜してください / 〜してくださいね / 教えてください / 教えて.
   These become a plain question or imperative in English, NOT "Please ___."
@@ -177,6 +194,9 @@ Output: How do I change the background color in WezTerm?
 
 Input: 効いてないのかな？
 Output: Is this not working?
+
+Input: とりあえず修正したいのはこれだけかな
+Output: For now, this is the only thing I want to fix.
 
 Input: 明日出社する
 Output: I'll come to the office tomorrow.
@@ -229,6 +249,13 @@ Style rules:
 - Drop hedge words and fillers entirely. They become NOTHING in English:
   ってか / なんですけど / 〜だけど / 〜のかな / 〜って感じ / まあ / なんか.
   NEVER translate them as "well", "also", "by the way", "I wonder if".
+- Translate sequencing/tentative adverbs by their TEMPORAL meaning, NOT as
+  uncertainty hedges:
+  とりあえず -> "for now" / "for the time being" / "as a first step".
+  ひとまず -> "for now" / "for the moment".
+  一旦 -> "for now" (when it means "tentatively, before doing more later").
+  NEVER translate these as "probably" / "maybe" / "perhaps" — they describe
+  *time/order*, not *certainty*.
 - Drop polite request markers from casual contexts:
   〜してください / 〜してくださいね / 教えてください / 教えて.
   These become a plain question or imperative in English, NOT "Please ___."
@@ -258,6 +285,9 @@ Output: How do I change the background color in WezTerm?
 
 Input: 効いてないのかな？
 Output: Is this not working?
+
+Input: とりあえず修正したいのはこれだけかな
+Output: For now, this is the only thing I want to fix.
 
 Input: 明日出社する
 Output: I'll come to the office tomorrow.


### PR DESCRIPTION
## Summary

- Models were rendering **とりあえず** as **"probably"** — conflating a sequencing adverb (time/order) with an uncertainty hedge. Spotted in the wild in a Claude-generated message: *"The only thing I want to fix for now is **probably** this one."*
- Added an explicit style rule + 1 example to all three LLM profiles (`openai`, `openai-mini`, `gemini`) covering とりあえず / ひとまず / 一旦.
- The new rule explicitly tells the model these adverbs describe *time/order*, not *certainty*.

## Test plan

- [x] `make check` (fmt + vet + lint + test) — passing
- [x] `make install` and verified new strings baked into binary (3× per profile)
- [x] Smoke test against all three profiles (4 cases × 3 profiles = 12):
  - とりあえず修正したいのはこれだけかな
  - とりあえずこれで commit しちゃう
  - ひとまず動くようにしたい
  - 一旦これで様子見
- [x] **12/12 PASS** — no `probably` / `maybe` / `perhaps` leakage on any profile.

Sample outputs (post-fix):

| Profile | Input | Output |
|---|---|---|
| openai | とりあえず修正したいのはこれだけかな | For now, is this the only thing you want to fix? |
| openai-mini | とりあえず修正したいのはこれだけかな | For now, this is the only thing I want to fix. |
| gemini | とりあえず修正したいのはこれだけかな | For now, this is the only thing I want to fix. |

Note: `openai` (nano) inferred subject as `you` instead of `I` — that's a separate subject-omission issue unrelated to this fix; mini & gemini got `I` correctly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)